### PR TITLE
Elasticsearch extra field plugin type added

### DIFF
--- a/modules/elasticsearch_helper_content/elasticsearch_helper_content.services.yml
+++ b/modules/elasticsearch_helper_content/elasticsearch_helper_content.services.yml
@@ -24,6 +24,10 @@ services:
   elasticsearch_helper_content.elasticsearch_data_type_repository:
     class: Drupal\elasticsearch_helper_content\ElasticsearchDataTypeRepository
 
+  elasticsearch_helper_content.normalizer_helper:
+    class: Drupal\elasticsearch_helper_content\ElasticsearchNormalizerHelper
+    arguments: ['@entity_type.manager', '@entity_display.repository']
+
   plugin.manager.elasticsearch_extra_field:
     class: Drupal\elasticsearch_helper_content\ElasticsearchExtraFieldManager
     parent: default_plugin_manager

--- a/modules/elasticsearch_helper_content/elasticsearch_helper_content.services.yml
+++ b/modules/elasticsearch_helper_content/elasticsearch_helper_content.services.yml
@@ -23,3 +23,7 @@ services:
 
   elasticsearch_helper_content.elasticsearch_data_type_repository:
     class: Drupal\elasticsearch_helper_content\ElasticsearchDataTypeRepository
+
+  plugin.manager.elasticsearch_extra_field:
+    class: Drupal\elasticsearch_helper_content\ElasticsearchExtraFieldManager
+    parent: default_plugin_manager

--- a/modules/elasticsearch_helper_content/src/Annotation/ElasticsearchExtraField.php
+++ b/modules/elasticsearch_helper_content/src/Annotation/ElasticsearchExtraField.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_content\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a Elasticsearch extra field item annotation object.
+ *
+ * @see \Drupal\elasticsearch_helper_content\ElasticsearchExtraFieldManager
+ * @see plugin_api
+ *
+ * @Annotation
+ */
+class ElasticsearchExtraField extends Plugin {
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The label of the plugin.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $label;
+
+}

--- a/modules/elasticsearch_helper_content/src/Annotation/ElasticsearchFieldNormalizer.php
+++ b/modules/elasticsearch_helper_content/src/Annotation/ElasticsearchFieldNormalizer.php
@@ -37,4 +37,11 @@ class ElasticsearchFieldNormalizer extends Plugin {
    */
   public $field_types;
 
+  /**
+   * Weight of the plugin.
+   *
+   * @var int
+   */
+  public $weight;
+
 }

--- a/modules/elasticsearch_helper_content/src/ElasticsearchExtraFieldBase.php
+++ b/modules/elasticsearch_helper_content/src/ElasticsearchExtraFieldBase.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_content;
+
+use Drupal\Component\Plugin\PluginBase;
+
+/**
+ * Base class for Elasticsearch extra field plugins.
+ */
+abstract class ElasticsearchExtraFieldBase extends PluginBase implements ElasticsearchExtraFieldInterface {
+
+}

--- a/modules/elasticsearch_helper_content/src/ElasticsearchExtraFieldInterface.php
+++ b/modules/elasticsearch_helper_content/src/ElasticsearchExtraFieldInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_content;
+
+use Drupal\Component\Plugin\PluginInspectionInterface;
+
+/**
+ * Defines an interface for Elasticsearch extra field plugins.
+ */
+interface ElasticsearchExtraFieldInterface extends PluginInspectionInterface {
+
+  /**
+   * Returns a list of Elasticsearch extra fields.
+   *
+   * @return \Drupal\elasticsearch_helper_content\ElasticsearchField[]
+   */
+  public function getFields();
+
+}

--- a/modules/elasticsearch_helper_content/src/ElasticsearchExtraFieldManager.php
+++ b/modules/elasticsearch_helper_content/src/ElasticsearchExtraFieldManager.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_content;
+
+use Drupal\Component\Plugin\Exception\PluginException;
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Provides the Elasticsearch extra field plugin manager.
+ */
+class ElasticsearchExtraFieldManager extends DefaultPluginManager {
+
+  /**
+   * Constructs a new ElasticsearchFieldManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct('Plugin/ElasticsearchExtraField', $namespaces, $module_handler, 'Drupal\elasticsearch_helper_content\ElasticsearchExtraFieldInterface', 'Drupal\elasticsearch_helper_content\Annotation\ElasticsearchExtraField');
+
+    $this->alterInfo('elasticsearch_extra_field_info');
+    $this->setCacheBackend($cache_backend, 'elasticsearch_extra_field_plugins');
+  }
+
+  /**
+   * Returns a list of Elasticsearch extra fields.
+   *
+   * @return \Drupal\elasticsearch_helper_content\ElasticsearchField[]
+   */
+  public function getExtraFields() {
+    static $result = NULL;
+
+    if (is_null($result)) {
+      $result = [];
+
+      foreach ($this->getDefinitions() as $plugin_id => $definition) {
+        try {
+          if ($instance = $this->createInstance($plugin_id)) {
+            /** @var \Drupal\elasticsearch_helper_content\ElasticsearchField[] $extra_fields */
+            if ($extra_fields = $instance->getFields()) {
+              foreach ($extra_fields as $extra_field) {
+                $result[$extra_field->getName()] = $extra_field;
+              }
+            }
+          }
+        }
+        catch (PluginException $e) {
+        }
+      }
+    }
+
+    return $result;
+  }
+
+}

--- a/modules/elasticsearch_helper_content/src/ElasticsearchField.php
+++ b/modules/elasticsearch_helper_content/src/ElasticsearchField.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_content;
+
+use Drupal\Core\Field\FieldDefinitionInterface;
+
+/**
+ * Class ElasticsearchField
+ */
+class ElasticsearchField {
+
+  /**
+   * @var string
+   */
+  protected $name;
+
+  /**
+   * @var string
+   */
+  protected $label;
+
+  /**
+   * @var string
+   */
+  protected $type;
+
+  /**
+   * ElasticsearchField constructor.
+   *
+   * @param $name
+   * @param $label
+   * @param $type
+   */
+  public function __construct($name, $label, $type) {
+    $this->name = $name;
+    $this->label = $label;
+    $this->type = $type;
+  }
+
+  /**
+   * Creates Elasticsearch field object from field definition.
+   *
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *
+   * @return \Drupal\elasticsearch_helper_content\ElasticsearchField
+   */
+  public static function createFromFieldDefinition(FieldDefinitionInterface $field_definition) {
+    return new static(
+      $field_definition->getName(),
+      $field_definition->getLabel(),
+      $field_definition->getType()
+    );
+  }
+
+  /**
+   * Returns field name.
+   *
+   * @return string
+   */
+  public function getName() {
+    return $this->name;
+  }
+
+  /**
+   * Returns field label.
+   *
+   * @return string
+   */
+  public function getLabel() {
+    return $this->label;
+  }
+
+  /**
+   * Returns field type.
+   *
+   * @return string
+   */
+  public function getType() {
+    return $this->type;
+  }
+
+}

--- a/modules/elasticsearch_helper_content/src/ElasticsearchFieldNormalizerBase.php
+++ b/modules/elasticsearch_helper_content/src/ElasticsearchFieldNormalizerBase.php
@@ -10,6 +10,35 @@ use Drupal\Core\Field\FieldItemInterface;
 abstract class ElasticsearchFieldNormalizerBase extends ElasticsearchNormalizerBase implements ElasticsearchFieldNormalizerInterface {
 
   /**
+   * @var string
+   */
+  protected $targetEntityType;
+
+  /**
+   * @var string
+   */
+  protected $targetBundle;
+
+  /**
+   * ElasticsearchFieldNormalizerBase constructor.
+   *
+   * @param array $configuration
+   * @param $plugin_id
+   * @param $plugin_definition
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+    if (!isset($configuration['entity_type'], $configuration['bundle'])) {
+      throw new \InvalidArgumentException(t('Entity type or bundle key is not provided in plugin configuration.'));
+    }
+
+    $this->targetEntityType = $configuration['entity_type'];
+    $this->targetBundle = $configuration['bundle'];
+    unset($configuration['entity_type'], $configuration['bundle']);
+
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function normalize($object, array $context = []) {

--- a/modules/elasticsearch_helper_content/src/ElasticsearchFieldNormalizerManager.php
+++ b/modules/elasticsearch_helper_content/src/ElasticsearchFieldNormalizerManager.php
@@ -37,8 +37,10 @@ class ElasticsearchFieldNormalizerManager extends DefaultPluginManager implement
 
     return array_filter($definitions, function ($definition) use ($type) {
       if (isset($definition['field_types'])) {
-        return in_array($type, $definition['field_types']);
+        // Qualify the definition if it supports the given type or all types.
+        return array_intersect(['all', $type], $definition['field_types']);
       }
+
       return FALSE;
     });
   }

--- a/modules/elasticsearch_helper_content/src/ElasticsearchFieldNormalizerManager.php
+++ b/modules/elasticsearch_helper_content/src/ElasticsearchFieldNormalizerManager.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\elasticsearch_helper_content;
 
+use Drupal\Component\Utility\SortArray;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -35,7 +36,7 @@ class ElasticsearchFieldNormalizerManager extends DefaultPluginManager implement
   public function getDefinitionsByFieldType($type) {
     $definitions = $this->getDefinitions();
 
-    return array_filter($definitions, function ($definition) use ($type) {
+    $result = array_filter($definitions, function ($definition) use ($type) {
       if (isset($definition['field_types'])) {
         // Qualify the definition if it supports the given type or all types.
         return array_intersect(['all', $type], $definition['field_types']);
@@ -43,6 +44,11 @@ class ElasticsearchFieldNormalizerManager extends DefaultPluginManager implement
 
       return FALSE;
     });
+
+    // Sort the plugins.
+    uasort($result, [SortArray::class, 'sortByWeightElement']);
+
+    return $result;
   }
 
 }

--- a/modules/elasticsearch_helper_content/src/ElasticsearchNormalizerHelper.php
+++ b/modules/elasticsearch_helper_content/src/ElasticsearchNormalizerHelper.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_content;
+
+use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Class ElasticsearchNormalizerHelper
+ */
+class ElasticsearchNormalizerHelper {
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * @var \Drupal\Core\Entity\EntityDisplayRepositoryInterface
+   */
+  protected $entityDisplayRepository;
+
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityDisplayRepositoryInterface $entity_display_repository) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityDisplayRepository = $entity_display_repository;
+  }
+
+  /**
+   * Returns a list of enabled view modes.
+   *
+   * @return array
+   */
+  public function getEntityViewDisplayOptions($entity_type = NULL, $bundle = NULL) {
+    $view_modes = [];
+
+    try {
+      // Get all view modes.
+      $view_modes = $this->entityDisplayRepository->getViewModes($entity_type);
+
+      // Get entity view display IDs (enabled view modes).
+      $entity_view_display_storage = $this->entityTypeManager->getStorage('entity_view_display');
+      $query = $entity_view_display_storage->getQuery()
+        ->condition('targetEntityType', $entity_type)
+        ->condition('bundle', $bundle)
+        ->condition('status', TRUE);
+
+      // Get the view modes from retrieved entity view displays.
+      $enabled_view_mode_ids = [];
+      if ($entity_view_display_result = $query->execute()) {
+        $enabled_view_mode_ids = array_map(function ($entity) {
+          /** @var \Drupal\Core\Entity\Entity\EntityViewDisplay $entity */
+          return $entity->getMode();
+        }, $entity_view_display_storage->loadMultiple($entity_view_display_result));
+      }
+
+      // Filter out view mode that are not enabled.
+      $view_modes = array_intersect_key($view_modes, array_flip($enabled_view_mode_ids));
+
+      // Get view mode labels.
+      $view_modes = array_map(function ($view_mode) {
+        return $view_mode['label'];
+      }, $view_modes);
+    }
+    catch (\Exception $e) {
+      watchdog_exception('elasticsearch_helper_content', $e);
+    }
+
+    return ['default' => t('Default')] + $view_modes;
+  }
+
+}

--- a/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchExtraField/RenderedContent.php
+++ b/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchExtraField/RenderedContent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_content\Plugin\ElasticsearchExtraField;
+
+use Drupal\elasticsearch_helper_content\ElasticsearchExtraFieldBase;
+use Drupal\elasticsearch_helper_content\ElasticsearchExtraFieldInterface;
+use Drupal\elasticsearch_helper_content\ElasticsearchField;
+
+/**
+ * @ElasticsearchExtraField(
+ *   id = "rendered_content",
+ *   label = @Translation("Rendered content")
+ * )
+ */
+class RenderedContent extends ElasticsearchExtraFieldBase implements ElasticsearchExtraFieldInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFields() {
+    return [
+      new ElasticsearchField('rendered_content', t('Rendered content'), 'rendered_content'),
+    ];
+  }
+
+}

--- a/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Entity/ElasticsearchEntityContentNormalizer.php
+++ b/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Entity/ElasticsearchEntityContentNormalizer.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @ElasticsearchEntityNormalizer(
  *   id = "content",
  *   label = @Translation("Content entity"),
- *   weight = 0
+ *   weight = 5
  * )
  */
 class ElasticsearchEntityContentNormalizer extends ElasticsearchEntityNormalizerBase {

--- a/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Entity/ElasticsearchEntityContentNormalizer.php
+++ b/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Entity/ElasticsearchEntityContentNormalizer.php
@@ -5,6 +5,7 @@ namespace Drupal\elasticsearch_helper_content\Plugin\ElasticsearchNormalizer\Ent
 use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\elasticsearch_helper_content\ElasticsearchNormalizerHelper;
 use Drupal\elasticsearch_helper_content\EntityRendererInterface;
 use Drupal\elasticsearch_helper_content\ElasticsearchDataTypeDefinition;
 use Drupal\elasticsearch_helper_content\ElasticsearchEntityNormalizerBase;
@@ -35,6 +36,11 @@ class ElasticsearchEntityContentNormalizer extends ElasticsearchEntityNormalizer
   protected $entityRenderer;
 
   /**
+   * @var \Drupal\elasticsearch_helper_content\ElasticsearchNormalizerHelper
+   */
+  protected $normalizerHelper;
+
+  /**
    * ElasticsearchEntityContentNormalizer constructor.
    *
    * @param array $configuration
@@ -44,12 +50,13 @@ class ElasticsearchEntityContentNormalizer extends ElasticsearchEntityNormalizer
    * @param \Drupal\Core\Entity\EntityDisplayRepositoryInterface $entity_display_repository
    * @param \Drupal\elasticsearch_helper_content\EntityRendererInterface $entity_renderer
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, EntityDisplayRepositoryInterface $entity_display_repository, EntityRendererInterface $entity_renderer) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, EntityDisplayRepositoryInterface $entity_display_repository, EntityRendererInterface $entity_renderer, ElasticsearchNormalizerHelper $normalizer_helper) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->entityTypeManager = $entity_type_manager;
     $this->entityDisplayRepository = $entity_display_repository;
     $this->entityRenderer = $entity_renderer;
+    $this->normalizerHelper = $normalizer_helper;
   }
 
   /**
@@ -62,7 +69,8 @@ class ElasticsearchEntityContentNormalizer extends ElasticsearchEntityNormalizer
       $plugin_definition,
       $container->get('entity_type.manager'),
       $container->get('entity_display.repository'),
-      $container->get('elasticsearch_helper_content.entity_renderer')
+      $container->get('elasticsearch_helper_content.entity_renderer'),
+      $container->get('elasticsearch_helper_content.normalizer_helper')
     );
   }
 
@@ -123,7 +131,7 @@ class ElasticsearchEntityContentNormalizer extends ElasticsearchEntityNormalizer
    * {@inheritdoc}
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
-    $entity_view_displays = $this->getEntityViewDisplayOptions();
+    $entity_view_displays = $this->normalizerHelper->getEntityViewDisplayOptions($this->configuration['entity_type'], $this->configuration['bundle']);
 
     return [
       '#tree' => TRUE,
@@ -142,49 +150,6 @@ class ElasticsearchEntityContentNormalizer extends ElasticsearchEntityNormalizer
         ],
       ],
     ];
-  }
-
-  /**
-   * Returns a list of enabled view modes.
-   *
-   * @return array
-   */
-  protected function getEntityViewDisplayOptions() {
-    $view_modes = [];
-
-    try {
-      // Get all view modes.
-      $view_modes = $this->entityDisplayRepository->getViewModes($this->configuration['entity_type']);
-
-      // Get entity view display IDs (enabled view modes).
-      $entity_view_display_storage = $this->entityTypeManager->getStorage('entity_view_display');
-      $query = $entity_view_display_storage->getQuery()
-        ->condition('targetEntityType', $this->configuration['entity_type'])
-        ->condition('bundle', $this->configuration['bundle'])
-        ->condition('status', TRUE);
-
-      // Get the view modes from retrieved entity view displays.
-      $enabled_view_mode_ids = [];
-      if ($entity_view_display_result = $query->execute()) {
-        $enabled_view_mode_ids = array_map(function ($entity) {
-          /** @var \Drupal\Core\Entity\Entity\EntityViewDisplay $entity */
-          return $entity->getMode();
-        }, $entity_view_display_storage->loadMultiple($entity_view_display_result));
-      }
-
-      // Filter out view mode that are not enabled.
-      $view_modes = array_intersect_key($view_modes, array_flip($enabled_view_mode_ids));
-
-      // Get view mode labels.
-      $view_modes = array_map(function ($view_mode) {
-        return $view_mode['label'];
-      }, $view_modes);
-    }
-    catch (\Exception $e) {
-      watchdog_exception('elasticsearch_helper_content', $e);
-    }
-
-    return ['default' => t('Default')] + $view_modes;
   }
 
   /**

--- a/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Entity/ElasticsearchEntityFieldNormalizer.php
+++ b/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Entity/ElasticsearchEntityFieldNormalizer.php
@@ -144,11 +144,17 @@ class ElasticsearchEntityFieldNormalizer extends ElasticsearchEntityNormalizerBa
       $entity_type = $this->entityTypeManager->getDefinition($object->getEntityTypeId());
 
       foreach ($this->getFieldNormalizerInstances() as $field_name => $field_normalizer_instance) {
-        // Convert field name if it's it's an entity key.
-        $entity_field_name = $entity_type->getKey($field_name) ?: $field_name;
+        // Allow field normalizer to normalize the whole entity.
+        if (method_exists($field_normalizer_instance, 'normalizeEntity')) {
+          $data[$field_name] = call_user_func([$field_normalizer_instance, 'normalizeEntity'], $object, $context);
+        }
+        else {
+          // Convert field name if it's it's an entity key.
+          $entity_field_name = $entity_type->getKey($field_name) ?: $field_name;
 
-        if ($object->hasField($entity_field_name)) {
-          $data[$field_name] = $field_normalizer_instance->normalize($object->get($entity_field_name), $context);
+          if ($object->hasField($entity_field_name)) {
+            $data[$field_name] = $field_normalizer_instance->normalize($object->get($entity_field_name), $context);
+          }
         }
       }
     }

--- a/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Entity/ElasticsearchEntityFieldNormalizer.php
+++ b/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Entity/ElasticsearchEntityFieldNormalizer.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @ElasticsearchEntityNormalizer(
  *   id = "field",
  *   label = @Translation("Content entity field"),
- *   weight = 5
+ *   weight = 0
  * )
  */
 class ElasticsearchEntityFieldNormalizer extends ElasticsearchEntityNormalizerBase {
@@ -144,17 +144,15 @@ class ElasticsearchEntityFieldNormalizer extends ElasticsearchEntityNormalizerBa
       $entity_type = $this->entityTypeManager->getDefinition($object->getEntityTypeId());
 
       foreach ($this->getFieldNormalizerInstances() as $field_name => $field_normalizer_instance) {
-        // Allow field normalizer to normalize the whole entity.
-        if (method_exists($field_normalizer_instance, 'normalizeEntity')) {
-          $data[$field_name] = call_user_func([$field_normalizer_instance, 'normalizeEntity'], $object, $context);
-        }
-        else {
-          // Convert field name if it's it's an entity key.
-          $entity_field_name = $entity_type->getKey($field_name) ?: $field_name;
+        // Convert field name if it's it's an entity key.
+        $entity_field_name = $entity_type->getKey($field_name) ?: $field_name;
 
-          if ($object->hasField($entity_field_name)) {
-            $data[$field_name] = $field_normalizer_instance->normalize($object->get($entity_field_name), $context);
-          }
+        if ($object->hasField($entity_field_name)) {
+          $data[$field_name] = $field_normalizer_instance->normalize($object->get($entity_field_name), $context);
+        }
+        // Allow field normalizer to normalize the whole entity.
+        elseif (method_exists($field_normalizer_instance, 'normalizeEntity')) {
+          $data[$field_name] = call_user_func([$field_normalizer_instance, 'normalizeEntity'], $object, $context);
         }
       }
     }

--- a/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Entity/ElasticsearchEntityFieldNormalizer.php
+++ b/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Entity/ElasticsearchEntityFieldNormalizer.php
@@ -469,6 +469,11 @@ class ElasticsearchEntityFieldNormalizer extends ElasticsearchEntityNormalizerBa
    * @throws \Drupal\Component\Plugin\Exception\PluginException
    */
   protected function createFieldNormalizerInstance($normalizer, array $normalizer_configuration, $entity_field_name) {
+    // Explicitly set entity type and bundle. They are unset in field
+    // normalizer plugins and are not stored in configuration.
+    $normalizer_configuration['entity_type'] = $this->targetEntityType;
+    $normalizer_configuration['bundle'] = $this->targetBundle;
+
     /** @var \Drupal\elasticsearch_helper_content\ElasticsearchNormalizerInterface $result */
     $result = $this->elasticsearchFieldNormalizerManager->createInstance($normalizer, $normalizer_configuration);
 

--- a/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Field/ElasticsearchFieldRenderedContentNormalizer.php
+++ b/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Field/ElasticsearchFieldRenderedContentNormalizer.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_content\Plugin\ElasticsearchNormalizer\Field;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\elasticsearch_helper_content\ElasticsearchDataTypeDefinition;
+use Drupal\elasticsearch_helper_content\ElasticsearchFieldNormalizerBase;
+use Drupal\elasticsearch_helper_content\ElasticsearchNormalizerHelper;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @ElasticsearchFieldNormalizer(
+ *   id = "rendered_content",
+ *   label = @Translation("Rendered content"),
+ *   field_types = {
+ *     "all"
+ *   },
+ *   weight = 5
+ * )
+ */
+class ElasticsearchFieldRenderedContentNormalizer extends ElasticsearchFieldNormalizerBase {
+
+  /**
+   * @var \Drupal\Core\Entity\EntityViewBuilderInterface
+   */
+  protected $viewBuilder;
+
+  /**
+   * @var \Drupal\elasticsearch_helper_content\ElasticsearchNormalizerHelper
+   */
+  protected $normalizerHelper;
+
+  /**
+   * @var \Drupal\Core\Render\Renderer
+   */
+  protected $renderer;
+
+  /**
+   * ElasticsearchFieldRenderedContentNormalizer constructor.
+   *
+   * @param array $configuration
+   * @param $plugin_id
+   * @param $plugin_definition
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   * @param \Drupal\elasticsearch_helper_content\ElasticsearchNormalizerHelper $normalizer_helper
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, ElasticsearchNormalizerHelper $normalizer_helper, RendererInterface $renderer) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->viewBuilder = $entity_type_manager->getViewBuilder($this->targetEntityType);
+    $this->normalizerHelper = $normalizer_helper;
+    $this->renderer = $renderer;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('elasticsearch_helper_content.normalizer_helper'),
+      $container->get('renderer')
+    );
+  }
+
+  /**
+   * Returns the rendered content of the entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $object
+   * @param array $context
+   *
+   * @return \Drupal\Component\Render\MarkupInterface|mixed
+   */
+  public function normalizeEntity($object, array $context = []) {
+    $build = $this->viewBuilder->view($object, $this->configuration['view_mode']);
+
+    return $this->renderer->renderRoot($build);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @param \Drupal\Core\Field\FieldItemInterface $object
+   */
+  public function normalize($object, array $context = []) {
+    $build = $object->view($this->configuration['view_mode']);
+
+    return $this->renderer->renderRoot($build);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPropertyDefinitions() {
+    return ElasticsearchDataTypeDefinition::create('keyword');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'view_mode' => 'default',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $entity_view_displays = $this->normalizerHelper->getEntityViewDisplayOptions($this->targetEntityType, $this->targetBundle);
+
+    return [
+      'view_mode' => [
+        '#type' => 'select',
+        '#title' => t('View mode'),
+        '#options' => $entity_view_displays,
+        '#default_value' => $this->configuration['view_mode'],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->configuration['view_mode'] = $form_state->getValue('view_mode');
+  }
+
+}

--- a/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Field/ElasticsearchFieldTextNormalizer.php
+++ b/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Field/ElasticsearchFieldTextNormalizer.php
@@ -35,27 +35,12 @@ class ElasticsearchFieldTextNormalizer extends ElasticsearchFieldNormalizerBase 
    * {@inheritdoc}
    */
   public function getPropertyDefinitions() {
-    $field_type = 'text';
-
-    // Determine data type.
-    switch ($this->configuration['storage_method']) {
-      case 'keyword':
-        $field_type = 'keyword';
-        break;
-
-      case 'text_keyword_field':
-        $field_name = 'keyword';
-        $field_definition = ElasticsearchDataTypeDefinition::create('keyword');
-        break;
-
-    }
-
-    // Prepare definition.
+    $field_type = $this->configuration['storage_type'];
     $definition = ElasticsearchDataTypeDefinition::create($field_type);
 
-    // Add fields (if available).
-    if (isset($field_name, $field_definition)) {
-      $definition->addField($field_name, $field_definition);
+    // Store raw value as keyword field.
+    if ($this->configuration['store_raw']) {
+      $definition->addField('raw', ElasticsearchDataTypeDefinition::create('keyword'));
     }
 
     return $definition;
@@ -66,7 +51,8 @@ class ElasticsearchFieldTextNormalizer extends ElasticsearchFieldNormalizerBase 
    */
   public function defaultConfiguration() {
     return [
-      'storage_method' => 'text',
+      'storage_type' => 'text',
+      'store_raw' => FALSE,
     ] + parent::defaultConfiguration();
   }
 
@@ -75,15 +61,28 @@ class ElasticsearchFieldTextNormalizer extends ElasticsearchFieldNormalizerBase 
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     return [
-      'storage_method' => [
+      'storage_type' => [
         '#type' => 'select',
-        '#title' => t('Storage method'),
+        '#title' => t('Storage type'),
         '#options' => [
           'text' => t('Text'),
           'keyword' => t('Keyword'),
-          'text_keyword_field' => t('Text with keyword field'),
         ],
-        '#default_value' => $this->configuration['storage_method'],
+        '#default_value' => $this->configuration['storage_type'],
+      ],
+      'store_raw' => [
+        '#type' => 'checkbox',
+        '#title' => t('Store raw value as keyword'),
+        '#weight' => 50,
+        '#default_value' => $this->configuration['store_raw'],
+        '#states' => [
+          'invisible' => [
+            ':input[name*="storage_type"]' => [
+              'value' => 'keyword',
+            ]
+          ],
+        ],
+
       ],
     ];
   }
@@ -92,7 +91,13 @@ class ElasticsearchFieldTextNormalizer extends ElasticsearchFieldNormalizerBase 
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
-    $this->configuration['storage_method'] = $form_state->getValue('storage_method');
+    $this->configuration['storage_type'] = $form_state->getValue('storage_type');
+    $this->configuration['store_raw'] = $form_state->getValue('store_raw');
+
+    // Do not store raw value if storage type is keyword.
+    if ($this->configuration['storage_type'] == 'keyword') {
+      $this->configuration['store_raw'] = FALSE;
+    }
   }
 
 }

--- a/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Field/ElasticsearchFieldTextNormalizer.php
+++ b/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchNormalizer/Field/ElasticsearchFieldTextNormalizer.php
@@ -19,7 +19,7 @@ use Drupal\elasticsearch_helper_content\ElasticsearchFieldNormalizerBase;
  *     "text_long",
  *     "text_with_summary",
  *     "list_string"
- *   },
+ *   }
  * )
  */
 class ElasticsearchFieldTextNormalizer extends ElasticsearchFieldNormalizerBase {


### PR DESCRIPTION
This change has the following features:
- allows adding Elasticsearch extra fields plugins to the list of fields to be saved in the index.
- adds `Rendered content` field normalizer plugin which allows storing the rendered output of any field or whole entity.
- adds `Render content` Elasticsearch extra field plugin which allows to store the output of the whole entity.